### PR TITLE
Updated Mongo .NET drivers to 2.0.1, mongod to 3.0.4

### DIFF
--- a/src/MongoDb.Embedded.Tests/BasicTests.cs
+++ b/src/MongoDb.Embedded.Tests/BasicTests.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using MongoDB.Bson;
+﻿using MongoDB.Driver;
 using NUnit.Framework;
 
 namespace MongoDB.Embedded.Tests
@@ -29,42 +22,39 @@ namespace MongoDB.Embedded.Tests
         }
 
         [Test]
-        public void ReadWriteTest()
+        public async void ReadWriteTest()
         {
             using (var embedded = new EmbeddedMongoDbServer())
             {
                 var client = embedded.Client;
-                var server = client.GetServer();
-                var db = server.GetDatabase("test");
+                var db = client.GetDatabase("test");
                 var collection = db.GetCollection<TestClass>("col");
-                collection.Save(new TestClass() {Id = 12345, TestValue = "Hello world."});
-                var retrieved = collection.FindOneById(12345);
+                await collection.InsertOneAsync(new TestClass() {Id = 12345, TestValue = "Hello world."});
+                var retrieved = await collection.Find(x => x.Id == 12345).SingleOrDefaultAsync();
                 Assert.NotNull(retrieved, "No object came back from the database.");
                 Assert.AreEqual("Hello world.", retrieved.TestValue, "Unexpected test value came back.");
             }
         }
 
         [Test]
-        public void DualServerReadWriteTest()
+        public async void DualServerReadWriteTest()
         {
             using (var embedded1 = new EmbeddedMongoDbServer())
             using (var embedded2 = new EmbeddedMongoDbServer())
             {
                 var client1 = embedded1.Client;
-                var server1 = client1.GetServer();
-                var db1 = server1.GetDatabase("test");
+                var db1 = client1.GetDatabase("test");
                 var collection1 = db1.GetCollection<TestClass>("col");
-                collection1.Save(new TestClass() { Id = 12345, TestValue = "Hello world." });
-                var retrieved1 = collection1.FindOneById(12345);
+                await collection1.InsertOneAsync(new TestClass() { Id = 12345, TestValue = "Hello world." });
+                var retrieved1 = await collection1.Find(x => x.Id == 12345).SingleOrDefaultAsync();
                 Assert.NotNull(retrieved1, "No object came back from the database.");
                 Assert.AreEqual("Hello world.", retrieved1.TestValue, "Unexpected test value came back.");
 
                 var client2 = embedded2.Client;
-                var server2 = client2.GetServer();
-                var db2 = server2.GetDatabase("test");
+                var db2 = client2.GetDatabase("test");
                 var collection2 = db2.GetCollection<TestClass>("col");
-                collection2.Save(new TestClass() { Id = 12345, TestValue = "Hello world." });
-                var retrieved2 = collection2.FindOneById(12345);
+                await collection2.InsertOneAsync(new TestClass() { Id = 12345, TestValue = "Hello world." });
+                var retrieved2 = await collection2.Find(x => x.Id == 12345).SingleOrDefaultAsync();
                 Assert.NotNull(retrieved2, "No object came back from the database.");
                 Assert.AreEqual("Hello world.", retrieved2.TestValue, "Unexpected test value came back.");
             }

--- a/src/MongoDb.Embedded.Tests/MongoDb.Embedded.Tests.csproj
+++ b/src/MongoDb.Embedded.Tests/MongoDb.Embedded.Tests.csproj
@@ -32,13 +32,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MongoDB.Bson, Version=1.8.2.34, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\mongocsharpdriver.1.8.2\lib\net35\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson, Version=2.0.1.27, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MongoDB.Bson.2.0.1\lib\net45\MongoDB.Bson.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="MongoDB.Driver, Version=1.8.2.34, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\mongocsharpdriver.1.8.2\lib\net35\MongoDB.Driver.dll</HintPath>
+    <Reference Include="MongoDB.Driver, Version=2.0.1.27, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MongoDB.Driver.2.0.1\lib\net45\MongoDB.Driver.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MongoDB.Driver.Core, Version=2.0.1.27, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MongoDB.Driver.Core.2.0.1\lib\net45\MongoDB.Driver.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>

--- a/src/MongoDb.Embedded.Tests/MongoDb.Embedded.Tests.csproj
+++ b/src/MongoDb.Embedded.Tests/MongoDb.Embedded.Tests.csproj
@@ -33,16 +33,16 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="MongoDB.Bson, Version=2.0.1.27, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\MongoDB.Bson.2.0.1\lib\net45\MongoDB.Bson.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="MongoDB.Driver, Version=2.0.1.27, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\MongoDB.Driver.2.0.1\lib\net45\MongoDB.Driver.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="MongoDB.Driver.Core, Version=2.0.1.27, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\MongoDB.Driver.Core.2.0.1\lib\net45\MongoDB.Driver.Core.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>

--- a/src/MongoDb.Embedded.Tests/packages.config
+++ b/src/MongoDb.Embedded.Tests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="mongocsharpdriver" version="1.8.2" targetFramework="net45" />
+  <package id="MongoDB.Bson" version="2.0.1" targetFramework="net45" />
+  <package id="MongoDB.Driver" version="2.0.1" targetFramework="net45" />
+  <package id="MongoDB.Driver.Core" version="2.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.2" targetFramework="net45" />
 </packages>

--- a/src/MongoDb.Embedded/MongoDb.Embedded.csproj
+++ b/src/MongoDb.Embedded/MongoDb.Embedded.csproj
@@ -8,7 +8,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <AssemblyName>MongoDB.Embedded</AssemblyName>
     <OutputType>Library</OutputType>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>

--- a/src/MongoDb.Embedded/MongoDb.Embedded.csproj
+++ b/src/MongoDb.Embedded/MongoDb.Embedded.csproj
@@ -38,16 +38,16 @@
   <ItemGroup>
     <Compile Include="JobObject.cs" />
     <Reference Include="MongoDB.Bson, Version=2.0.1.27, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\MongoDB.Bson.2.0.1\lib\net45\MongoDB.Bson.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="MongoDB.Driver, Version=2.0.1.27, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\MongoDB.Driver.2.0.1\lib\net45\MongoDB.Driver.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="MongoDB.Driver.Core, Version=2.0.1.27, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\MongoDB.Driver.Core.2.0.1\lib\net45\MongoDB.Driver.Core.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/MongoDb.Embedded/MongoDb.Embedded.csproj
+++ b/src/MongoDb.Embedded/MongoDb.Embedded.csproj
@@ -37,13 +37,17 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Compile Include="JobObject.cs" />
-    <Reference Include="MongoDB.Bson, Version=1.8.2.34, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\mongocsharpdriver.1.8.2\lib\net35\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson, Version=2.0.1.27, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MongoDB.Bson.2.0.1\lib\net45\MongoDB.Bson.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="MongoDB.Driver, Version=1.8.2.34, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\mongocsharpdriver.1.8.2\lib\net35\MongoDB.Driver.dll</HintPath>
+    <Reference Include="MongoDB.Driver, Version=2.0.1.27, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MongoDB.Driver.2.0.1\lib\net45\MongoDB.Driver.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MongoDB.Driver.Core, Version=2.0.1.27, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\MongoDB.Driver.Core.2.0.1\lib\net45\MongoDB.Driver.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/MongoDb.Embedded/packages.config
+++ b/src/MongoDb.Embedded/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="mongocsharpdriver" version="1.8.2" targetFramework="net40" />
+  <package id="MongoDB.Bson" version="2.0.1" targetFramework="net45" />
+  <package id="MongoDB.Driver" version="2.0.1" targetFramework="net45" />
+  <package id="MongoDB.Driver.Core" version="2.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
As in title, tests have also been updated to conform to the new Mongo .NET API.